### PR TITLE
fix isBarricadeAction not allowing barricades when using a ball-peen hammer

### DIFF
--- a/client/TimedActions/ISBarricadeAction.lua
+++ b/client/TimedActions/ISBarricadeAction.lua
@@ -32,7 +32,10 @@ function ISBarricadeAction:isValid()
 		if barricade and not barricade:canAddPlank() then
 			return false
 		end
-		if not self.character:hasEquipped("Hammer") and not self.character:hasEquipped("HammerStone") then
+		if not self.character:hasEquipped("Hammer") and
+		   not self.character:hasEquipped("HammerStone") and
+		   not self.character:hasEquipped("BallPeenHammer")
+		then
 			return false
 		end
 		if not self.character:hasEquipped("Plank") then


### PR DESCRIPTION
Couldn't barricade anything with my character because I was using a Ball-peen hammer. Debug mode pointed to this function `isBarricadeAction` and turns out there was a check missing for this type of hammer.